### PR TITLE
[HOTFIX] Removed stubbed server protocol in sendHttpStatusHeader.

### DIFF
--- a/classes/AppController.class.php
+++ b/classes/AppController.class.php
@@ -35,7 +35,7 @@ class AppController extends Lvc_PageController
 	{
 		include_once('HttpStatusCode.class.php');
 		$statusCode = new HttpStatusCode($code);
-		header('HTTP/1.1 ' . $statusCode->getCode() . ' ' . $statusCode->getDefinition());
+		header($_SERVER["SERVER_PROTOCOL"] . ' ' . $statusCode->getCode() . ' ' . $statusCode->getDefinition());
 		return $statusCode;
 	}
 	

--- a/classes/AppController.class.php
+++ b/classes/AppController.class.php
@@ -35,7 +35,11 @@ class AppController extends Lvc_PageController
 	{
 		include_once('HttpStatusCode.class.php');
 		$statusCode = new HttpStatusCode($code);
-		header($_SERVER["SERVER_PROTOCOL"] . ' ' . $statusCode->getCode() . ' ' . $statusCode->getDefinition());
+
+		// Ensure the server protocol is supplied. Otherwise we fallback to stubbed string "HTTP/1.1".
+		$serverProtocol = (isset($_SERVER["SERVER_PROTOCOL"])) ? $_SERVER["SERVER_PROTOCOL"] : 'HTTP/1.1';
+		header($serverProtocol . ' ' . $statusCode->getCode() . ' ' . $statusCode->getDefinition());
+		
 		return $statusCode;
 	}
 	


### PR DESCRIPTION
Replaced stubbed 'HTTP/1.1' to $_SERVER["SERVER_PROTOCOL"].

Some HTTP proxy servers may use different protocols, which can cause HTTP headers be overwritten causing false status codes at times. Plus this change will also future prof for upcoming HTTP 2.
